### PR TITLE
Do not delete the database dump if --skip-db

### DIFF
--- a/createBackup.sh
+++ b/createBackup.sh
@@ -359,8 +359,10 @@ fi
 consoleWriteLine "Done."
 
 # Now that the database dump is packed up, delete it
-consoleWriteVerbose "Deleting database dump..."
-rm --force -- $BASE/database.sql
+if [[ "false" == $SKIP_DB ]]; then
+  consoleWriteVerbose "Deleting database dump..."
+  rm --force -- $BASE/database.sql
+fi
 consoleWriteLineVerbose "Done!"
 
 # vim:ts=2:sw=2:expandtab:


### PR DESCRIPTION
If the --skip-db flag is set we do not want to delete the database.sql file that
we didn't create.
